### PR TITLE
Update grafů na novou PyPI verzi

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -117,7 +117,7 @@ dj-fiobank-payments = "<=0.3.0"
 asgiref="*"
 django-dbtemplates = "*"
 django-reversion = "*"
-django-admin-charts = {git = "https://github.com/PetrDlouhy/django-admin-charts",editable = true,ref = "develop"}
+django-admin-charts = "*"
 django-inline-static = "*"
 
 [requires]


### PR DESCRIPTION
Díky nim bude možné zobrazovat Tripy podle `date` (teď jsou podle `created`, což zkresluje data) a nová verze obsahuje i další uživatelská vylepšení.