### PR TITLE
enable debug toolbar for superusers when debug_toolbar get parameter is in URL

### DIFF
--- a/project/settings/dev.py
+++ b/project/settings/dev.py
@@ -141,8 +141,9 @@ DEBUG_TOOLBAR_PANELS = [
 
 
 def custom_show_toolbar(request):
-    if request.META['SERVER_NAME'] != 'testserver':
-        return True  # Always show toolbar, for example purposes only.
+    if request.user and request.user.is_superuser and 'debug_toolbar' in request.GET:
+        return True
+    return False
 
 
 DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
@timthelion Myslím, že by bylo velmi užitečné mít možnost zapnout debug toolbar na testovacím serveru a potenciálně i na ostrém. Tahle změna ho zapíná, pokud jsi superuser a máš v url parametr `?debug_toolbar`.
Nevím, jestli už samotné `DEBUG_TOOLBAR = True` může nějak zpomalovat server, každopádně na testu to teď zapínám, abych mohl vyšetřit to zpomalení. Na ostrém by bylo potřeba to důkladně otestovat, kdybychom to chtěli zapnout.