### PR TITLE
Apple m1 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ node_modules/
 db/*
 avatar_locale/locale/en/LC_MESSAGES/django.po
 tmp_gls/*
+.idea

--- a/DockerfileDev
+++ b/DockerfileDev
@@ -1,5 +1,5 @@
-FROM dpnk-base
+FROM --platform=linux/amd64 dpnk-base
 RUN useradd test
 RUN chsh test -s /bin/bash
 RUN mkdir /home/test ; chown test /home/test ; chgrp test /home/test
-run mkdir -p /opt/poetry ; chown -R test /opt/poetry
+RUN mkdir -p /opt/poetry ; chown -R test /opt/poetry


### PR DESCRIPTION
Set default platform to build the base image on. This solves an issue with Apple m1 arm.