### PR TITLE
setup.sh: compile locale messages only for DPNK project

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,5 +8,5 @@ poetry run python3 manage.py loaddata apps/dpnk/fixtures/commute_mode.json
 poetry run python3 manage.py loaddata apps/dpnk/fixtures/sites.json
 poetry run python3 manage.py loaddata apps/dpnk/fixtures/occupation.json
 poetry run python3 manage.py loaddata apps/dpnk/fixtures/test-campaign.json
-poetry run python3 manage.py compilemessages
+cd apps/ && poetry run python3 ../manage.py compilemessages && cd ../
 poetry run python3 manage.py createsuperuser


### PR DESCRIPTION
Compile locale messages only for DPNK project, not for all venv files.

**Expected behavior:**

```
test@221613049d4f:/app-v$ cd apps/ && poetry run python3 ../manage.py compilemessages && cd ../
processing file django.po in /app-v/apps/t_shirt_delivery/locale/en/LC_MESSAGES
processing file django.po in /app-v/apps/t_shirt_delivery/locale/cs/LC_MESSAGES
processing file django.po in /app-v/apps/dpnk/locale/en/LC_MESSAGES
processing file django.po in /app-v/apps/dpnk/locale/dsnkcs/LC_MESSAGES
processing file django.po in /app-v/apps/dpnk/locale/cs/LC_MESSAGES
processing file django.po in /app-v/avatar_locale/locale/cs/LC_MESSAGES
processing file django.po in /app-v/apps/stravasync/locale/en/LC_MESSAGES
processing file django.po in /app-v/apps/stravasync/locale/dsnkcs/LC_MESSAGES
processing file django.po in /app-v/apps/stravasync/locale/cs/LC_MESSAGES
processing file django.po in /app-v/apps/coupons/locale/en/LC_MESSAGES
processing file django.po in /app-v/apps/coupons/locale/cs/LC_MESSAGES
```