### PR TITLE
apps/t_shirt_delivery: fix get TShirtSize models

### DIFF
--- a/apps/t_shirt_delivery/delivery_batch_resources.py
+++ b/apps/t_shirt_delivery/delivery_batch_resources.py
@@ -44,7 +44,7 @@ def get_all_t_shirt_codes(value_field):
     """
     if sys.argv[1] == "test":
         return ("TEST",)
-    # During build Docker image DB isnt accessible
+    # During build Docker image DB isn't accessible
     try:
         codes = set(
             TShirtSize.objects.all().values_list(value_field, flat=True),

--- a/apps/t_shirt_delivery/delivery_batch_resources.py
+++ b/apps/t_shirt_delivery/delivery_batch_resources.py
@@ -50,8 +50,8 @@ def get_all_t_shirt_codes(value_field):
         codes = {}
         # Check if "TShirtSize" model DB table exist, during tests
         if (
-            TShirtSize._meta.db_table in
-            connections["default"].introspection.table_names()
+            TShirtSize._meta.db_table
+            in connections["default"].introspection.table_names()
         ):
             codes = set(
                 TShirtSize.objects.all().values_list(value_field, flat=True),

--- a/apps/t_shirt_delivery/delivery_batch_resources.py
+++ b/apps/t_shirt_delivery/delivery_batch_resources.py
@@ -1,6 +1,8 @@
 import sys
 from operator import itemgetter
 
+from django.core.exceptions import ImproperlyConfigured
+
 from import_export import fields
 from import_export.resources import ModelResource
 
@@ -42,10 +44,14 @@ def get_all_t_shirt_codes(value_field):
     """
     if sys.argv[1] == "test":
         return ("TEST",)
-    codes = set(
-        TShirtSize.objects.all().values_list(value_field, flat=True),
-    )
-    codes.difference_update(["", "nic"])
+    # During build Docker image DB isnt accessible
+    try:
+        codes = set(
+            TShirtSize.objects.all().values_list(value_field, flat=True),
+        )
+        codes.difference_update(["", "nic"])
+    except ImproperlyConfigured:
+        codes = {}
     return codes
 
 

--- a/apps/t_shirt_delivery/delivery_batch_resources.py
+++ b/apps/t_shirt_delivery/delivery_batch_resources.py
@@ -5,7 +5,7 @@ from import_export import fields
 from import_export.resources import ModelResource
 
 from .models import TShirtSize
-from .test.test_admin import DeliveryBatchAdminTests
+from t_shirt_delivery.test.test_admin import DeliveryBatchAdminTests
 
 
 def dehydrate_decorator(value_field, t_shirt_code_name):

--- a/apps/t_shirt_delivery/delivery_batch_resources.py
+++ b/apps/t_shirt_delivery/delivery_batch_resources.py
@@ -5,7 +5,6 @@ from import_export import fields
 from import_export.resources import ModelResource
 
 from .models import TShirtSize
-from t_shirt_delivery.test.test_admin import DeliveryBatchAdminTests
 
 
 def dehydrate_decorator(value_field, t_shirt_code_name):
@@ -42,7 +41,7 @@ def get_all_t_shirt_codes(value_field):
     :return set codes: unique t-shirts codes
     """
     if sys.argv[1] == "test":
-        return (DeliveryBatchAdminTests.t_shirt_code,)
+        return ("TEST",)
     codes = set(
         TShirtSize.objects.all().values_list(value_field, flat=True),
     )

--- a/apps/t_shirt_delivery/test/test_admin.py
+++ b/apps/t_shirt_delivery/test/test_admin.py
@@ -159,10 +159,9 @@ class PackageTransactionTests(AdminTestBase):
 
 
 class DeliveryBatchAdminTests(AdminTestBase):
-    t_shirt_code = "TEST"
-
     def setUp(self):
         super().setUp()
+        self.t_shirt_code = "TEST"
         self.campaign = testing_campaign
         self.t_shirt_size = mommy.make(
             "TShirtSize",

--- a/project/settings/test.py
+++ b/project/settings/test.py
@@ -36,7 +36,7 @@ CACHES = {
 DATABASES = {
     "default": {
         "ENGINE": "django.contrib.gis.db.backends.postgis",
-        "NAME": os.environ.get("DB", "circle_test"),
+        "NAME": os.environ.get("DPNK_DB_NAME", "circle_test"),
         "USER": os.environ.get("DPNK_DB_USER", "ubuntu"),
         "PASSWORD": os.environ.get("DPNK_DB_PASSWORD", ""),
         "HOST": os.environ.get("DPNK_DB_HOST", "localhost"),

--- a/project/settings/test.py
+++ b/project/settings/test.py
@@ -36,13 +36,13 @@ CACHES = {
 DATABASES = {
     "default": {
         "ENGINE": "django.contrib.gis.db.backends.postgis",
-        "NAME": os.environ.get("DB", "circle_test"),
+        "NAME": os.environ.get("DPNK_DB_NAME", "circle_test"),
         "USER": os.environ.get("DPNK_DB_USER", "ubuntu"),
         "PASSWORD": os.environ.get("DPNK_DB_PASSWORD", ""),
         "HOST": os.environ.get("DPNK_DB_HOST", "localhost"),
         "PORT": os.environ.get("DPNK_DB_PORT", ""),
         "TEST": {
-            "NAME": os.environ.get("DB", "circle_test"),
+            "NAME": os.environ.get("DPNK_DB_NAME", "circle_test"),
         },
     },
 }

--- a/project/settings/test.py
+++ b/project/settings/test.py
@@ -36,13 +36,13 @@ CACHES = {
 DATABASES = {
     "default": {
         "ENGINE": "django.contrib.gis.db.backends.postgis",
-        "NAME": os.environ.get("DPNK_DB_NAME", "circle_test"),
+        "NAME": os.environ.get("DB", "circle_test"),
         "USER": os.environ.get("DPNK_DB_USER", "ubuntu"),
         "PASSWORD": os.environ.get("DPNK_DB_PASSWORD", ""),
         "HOST": os.environ.get("DPNK_DB_HOST", "localhost"),
         "PORT": os.environ.get("DPNK_DB_PORT", ""),
         "TEST": {
-            "NAME": os.environ.get("DPNK_DB_NAME", "circle_test"),
+            "NAME": os.environ.get("DB", "circle_test"),
         },
     },
 }


### PR DESCRIPTION
Fixes:

1. Handle exception if DB connection is not defined for getting `TShirtSize` models in `get_all_t_shirt_codes()` function (during build Docker image)
2. Don't read `TShirtSize` models in `get_all_t_shirt_codes()` function, if DB table doesn't exist (migration wasn't applied)
3. [Test settings file](https://github.com/auto-mat/do-prace-na-kole/blob/master/project/settings/test.py#L39) `DATABASE` settings fix global variable DB connection name. `DB` variable name should be `DPNK_DB_NAME`.
4. Replace getting `DeliveryBatchAdminTests.t_shirt_code` class value in `get_all_t_shirt_codes()` with string.