### PR TITLE
project/settings/base.py: fix parse FAKTUROID_DATE_FROM_CREATE_INVOICES var if it's empty string

### DIFF
--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -833,7 +833,7 @@ def get_formatted_date(name):
     :return timezone.datetime instance/None: global var date value
     """
     val = os.getenv(name)
-    if isinstance(val, str):
+    if val and isinstance(val, str):
         return timezone.datetime.strptime(val, "%Y-%m-%d")  # ISO 8601
     return val
 


### PR DESCRIPTION
Fix parse `FAKTUROID_DATE_FROM_CREATE_INVOICES` var if it's empty string.