### PR TITLE
monorepo/docker-base-image: fix ogr2ogr error related with export geodata to PostgreSQL version >= 12

### DIFF
--- a/monorepo/docker-base-image/Dockerfile
+++ b/monorepo/docker-base-image/Dockerfile
@@ -1,4 +1,4 @@
-from python:3.9-buster
+from python:3.9-bullseye
 
 maintainer Automat
 


### PR DESCRIPTION
Fix ogr2ogr error related with export geodata to PostgreSQL version >= 12.

**Error message:**

```
ERROR 1: ERROR:  column s.consrc does not exist
LINE 1: ...nrelid = c.oid AND a.attnum = ANY (s.conkey) AND (s.consrc L...
                                                             ^
HINT:  Perhaps you meant to reference the column "s.conkey" or the column "s.conbin".

ERROR 1: ERROR:  column s.consrc does not exist
LINE 1: ...nrelid = c.oid AND a.attnum = ANY (s.conkey) AND (s.consrc L...
                                                             ^
HINT:  Perhaps you meant to reference the column "s.conkey" or the column "s.conbin".

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: CREATE TABLE "public"."city" ( "ogc_fid" SERIAL, PRIMARY KEY ("ogc_fid"), "osm_id" INT8, "the_geom" geometry(POLYGON,1) )
ERROR:  current transaction is aborted, commands ignored until end of transaction block

ERROR 1: Unable to write feature 0 from layer SELECT.
ERROR 1: Terminating translation prematurely after failed
```