### PR TITLE
dpnk/templates/dpnk: escape JS string in the template

### DIFF
--- a/apps/dpnk/templates/dpnk/calendar.js
+++ b/apps/dpnk/templates/dpnk/calendar.js
@@ -12,7 +12,7 @@ var commute_modes = {
         'eco': {{cm.eco|yesno:"true,false" }},
         'name': "{{cm.name}}",
         'add_command': "{{cm.add_command}}",
-        'choice_description': "{{cm.choice_description|safe}}",
+        'choice_description': "{{cm.choice_description|escapejs}}",
         'does_count': {{cm.does_count|yesno:"true,false" }},
         'icon_html': "{{cm.icon_html|urlencode}}",
         'points': "{{cm.points_display}}",


### PR DESCRIPTION
Escape double quotes inside `commute_mode` JS var. Especially when text with double quotes is typed in the `CommuteMode` model choice_description field. Fixes #282.

