### PR TITLE
apps/dpnk: upgrade to Fakturoid API V3 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
                --env DPNK_DB_PASSWORD=password \
                --env DPNK_BROKER_URL="amqp://rabbit" \
                --env FAKTUROID_INVOICE_NUMBER_WIDTH=4 \
-               --env FAKTUROID_BASE_REST_API_URL="https://app.fakturoid.cz/api/v2" \
+               --env FAKTUROID_BASE_REST_API_URL="https://app.fakturoid.cz/api/v3" \
                --env FAKTUROID_TEST_USER_ACCOUNT=$FAKTUROID_TEST_USER_ACCOUNT \
                --env FAKTUROID_TEST_USER_EMAIL="$FAKTUROID_TEST_USER_EMAIL" \
                --env FAKTUROID_TEST_API_KEY=$FAKTUROID_TEST_API_KEY \

--- a/apps/dpnk/fakturoid_invoice_gen.py
+++ b/apps/dpnk/fakturoid_invoice_gen.py
@@ -1,44 +1,168 @@
-"""Create Fakturoid invoice"""
+"""Create Fakturoid invoice using API V3"""
 
 import decimal
 import logging
 import re
 import requests
+import json
+import base64
+from datetime import datetime
 
 from django.conf import settings
-
-from fakturoid import Fakturoid, Invoice, InvoiceLine, Subject
-
-from .fakturoid_invoice_send_by_email import send_invoice_by_email
 
 logger = logging.getLogger(__name__)
 
 
-def create_or_update_subject(fa, invoice):
-    """Create or update Fakturoid subject
+def get_invoice(session, base_url, invoice_id):
+    """Get Fakturoid invoice by custom ID using API V3
 
-    :param class instance fa: fakturoid.Fakturoid class instance
-    :param class instance: Invoice model class instance
+    :param session: requests session with authentication
+    :param str base_url: Base URL for API calls
+    :param str/int invoice_id: ID of the invoice to retrieve
 
-    :return Fakturoid Subject class instance/None fa_subject: Fakturoid
-                                                              Subject class
-                                                              instance
-                                                              or None
+    :return dict/None: Fakturoid Invoice data or None
+    """
+    error_message = (
+        "Getting Fakturoid invoice with ID {invoice_id}"
+        " wasn't successful with Fakturoid account"
+        " '{fakturoid_account}' due error: '{error}'"
+    )
+
+    try:
+        # Get invoice by ID
+        response = session.get(f"{base_url}/invoices.json?custom_id={invoice_id}")
+        response.raise_for_status()
+        return response.json()[0]
+    except requests.RequestException as error:
+        logger.error(
+            error_message.format(
+                invoice_id=invoice_id,
+                fakturoid_account=base_url.split("/")[-2],
+                error=error,
+            )
+        )
+        return None
+
+
+def delete_invoice(session, base_url, invoice_id):
+    """Delete Fakturoid invoice by ID using API V3
+
+    :param session: requests session with authentication
+    :param str base_url: Base URL for API calls
+    :param str/int invoice_id: ID of the invoice to delete
+
+    :return bool: True if successful, False otherwise
+    """
+    error_message = (
+        "Deleting Fakturoid invoice with ID {invoice_id}"
+        " wasn't successful with Fakturoid account"
+        " '{fakturoid_account}' due error: '{error}'"
+    )
+
+    try:
+        fakturoid_id = get_invoice(session, base_url, invoice_id)["id"]
+        # Delete invoice by ID
+        response = session.delete(f"{base_url}/invoices/{fakturoid_id}.json")
+
+        # If successfully deleted, the server will respond with status 204 No Content
+        if response.status_code == 204:
+            return True
+
+        # If invoice cannot be deleted, the server will respond with status 422 Unprocessable Entity
+        if response.status_code == 422:
+            logger.error(
+                f"Invoice with ID {invoice_id} cannot be deleted. "
+                "This may be because it's a proforma with connected paid invoice, "
+                "an invoice with correction invoice, a proforma with tax documents, "
+                "a tax document with connected invoice, or the document is locked."
+            )
+            return False
+
+        # Handle other error responses
+        response.raise_for_status()
+        return True
+
+    except requests.RequestException as error:
+        logger.error(
+            error_message.format(
+                invoice_id=invoice_id,
+                fakturoid_account=base_url.split("/")[-2],
+                error=error,
+            )
+        )
+        return False
+
+def delete_subject(session, base_url, subject_id):
+    """Delete Fakturoid subject by ID using API V3
+
+    :param session: requests session with authentication
+    :param str base_url: Base URL for API calls
+    :param str/int subject_id: ID of the subject to delete
+
+    :return bool: True if successful, False otherwise
+    """
+    error_message = (
+        "Deleting Fakturoid subject with ID {subject_id}"
+        " wasn't successful with Fakturoid account"
+        " '{fakturoid_account}' due error: '{error}'"
+    )
+
+    try:
+        # Delete subject by ID
+        response = session.delete(f"{base_url}/subjects/{subject_id}.json")
+
+        # If successfully deleted, the server will respond with status 204 No Content
+        if response.status_code == 204:
+            return True
+
+        # If subject cannot be deleted because it contains documents, 
+        # the server will respond with status 403 Forbidden
+        if response.status_code == 403:
+            logger.error(
+                f"Subject with ID {subject_id} cannot be deleted. "
+                "This is likely because the subject contains documents."
+            )
+            return False
+
+        # Handle other error responses
+        response.raise_for_status()
+        return True
+
+    except requests.RequestException as error:
+        logger.error(
+            error_message.format(
+                subject_id=subject_id,
+                fakturoid_account=base_url.split("/")[-2],
+                error=error,
+            )
+        )
+        return False
+
+
+def create_or_update_subject(session, base_url, invoice):
+    """Create or update Fakturoid subject using API V3
+
+    :param session: requests session with authentication
+    :param str base_url: Base URL for API calls
+    :param class instance invoice: Invoice model class instance
+
+    :return dict/None: Fakturoid Subject data or None
     """
     error_message = (
         "{state} Fakturoid subject {subject_custom_id}"
-        " wasn't succesfull with Fakturoid account"
-        " '{fakturoid_user_account_slug}' due error: '{error}'"
+        " wasn't successful with Fakturoid account"
+        " '{fakturoid_account}' due error: '{error}'"
     )
-    # Subject
+
+    # Subject data
     pattern = re.compile(r"\s+")
     fa_subject_data = {
-        "custom_id": invoice.company.id,
+        "custom_id": str(invoice.company.id),
         "name": invoice.company_name,
         "street": (
             f"{invoice.company.address.street or ''} "
             f"{invoice.company.address.street_number or ''}"
-        ),
+        ).strip(),
         "zip": invoice.company_address_psc,
         "country": invoice.country or "CZ",
         "registration_no": invoice.company_ico,
@@ -51,52 +175,58 @@ def create_or_update_subject(fa, invoice):
         ),
         "note": invoice.client_note,
     }
+
     fa_subject_emails = invoice.company_admin_emails().split(",")
     fa_subject_data["email"] = fa_subject_emails[0]
     if len(fa_subject_emails) == 2:
         fa_subject_data["email_copy"] = fa_subject_emails[1]
 
-    fa_subject = fa.subjects(custom_id=invoice.company.id)
-    if not fa_subject:
-        fa_subject = Subject(**fa_subject_data)
-        state = "Create"
-        subject_custom_id = ""
-    else:
-        fa_subject = fa_subject[0]
-        fa_subject.update(fa_subject_data)
-        state = "Update"
-        subject_custom_id = f"with custom_id = {fa_subject.custom_id}"
+    # Check if subject exists
     try:
-        fa.save(fa_subject)
-    except (
-        requests.RequestException,
-        requests.ConnectionError,
-        requests.HTTPError,
-        requests.URLRequired,
-        requests.TooManyRedirects,
-        requests.Timeout,
-    ) as error:
+        response = session.get(f"{base_url}/subjects.json", params={"custom_id": invoice.company.id})
+        response.raise_for_status()
+        subjects = response.json()
+
+        if subjects:
+            # Update existing subject
+            subject_id = subjects[0]["id"]
+            state = "Update"
+            subject_custom_id = f"with custom_id = {invoice.company.id}"
+            response = session.patch(
+                f"{base_url}/subjects/{subject_id}.json",
+                json=fa_subject_data
+            )
+            response.raise_for_status()
+            return response.json()
+        else:
+            # Create new subject
+            state = "Create"
+            subject_custom_id = ""
+            response = session.post(
+                f"{base_url}/subjects.json",
+                json=fa_subject_data
+            )
+            response.raise_for_status()
+            return response.json()
+    except requests.RequestException as error:
         logger.error(
             error_message.format(
                 state=state,
                 subject_custom_id=subject_custom_id,
-                invoice_custom_id=invoice.id,
-                fakturoid_user_account_slug=fa.slug,
+                fakturoid_account=base_url.split("/")[-2],
                 error=error,
             )
         )
-        fa_subject = None
-    return fa_subject
+        return None
 
 
 def create_invoice_lines(invoice):
-    """Make Fakturoiud invoice lines
+    """Make Fakturoid invoice lines
 
     :param class instance invoice: Invoice model class instance
 
-    :return list lines: list of InvoiceLine class model instaces
+    :return list lines: list of invoice line dictionaries
     """
-
     lines = []
     for payment in invoice.payment_set.order_by(
         "user_attendance__userprofile__user__last_name",
@@ -110,151 +240,264 @@ def create_invoice_lines(invoice):
             "" if invoice.anonymize else payment.user_attendance.name_for_trusted()
         )
         description = f"Platba za soutěžící/ho {user_name}"
-        lines.append(
-            # https://fakturoid.docs.apiary.io/#reference/lines
-            InvoiceLine(
-                name=description,
-                quantity=1,
-                unit_price=decimal.Decimal(amount),
-                vat_rate=0,
-            )
-        )
+        lines.append({
+            "name": description,
+            "quantity": 1,
+            "unit_price": str(decimal.Decimal(amount)),
+            "vat_rate": 0
+        })
     return lines
 
 
-def create_or_update_invoice(fa, subject, invoice):
-    """Create or update Fakturoid invoice
+def create_or_update_invoice(session, base_url, subject, invoice):
+    """Create or update Fakturoid invoice using API V3
 
-    :param class instance fa: fakturoid.Fakturoid class instance
-    :param class instance subject: fakturoid.Subject model class instance
-    :param class instance: Invoice model class instance
+    :param session: requests session with authentication
+    :param str base_url: Base URL for API calls
+    :param dict subject: Fakturoid subject data
+    :param class instance invoice: Invoice model class instance
 
-    :return Fakturoid Invoice class instance/None fa_invoice: Fakturoid
-                                                              Invoice
-                                                              class instance
-                                                              or None
+    :return dict/None: Fakturoid Invoice data or None
     """
     error_message = (
-        "{state} Fakturoid invoice {subject_custom_id}"
-        " wasn't succesfull with Fakturoid account"
-        " '{fakturoid_user_account_slug}' due error: '{error}'"
+        "{state} Fakturoid invoice {invoice_custom_id}"
+        " wasn't successful with Fakturoid account"
+        " '{fakturoid_account}' due error: '{error}'"
     )
-    # Invoice
-    fa_invoice = fa.invoices(custom_id=invoice.id)
+
+    # Check if invoice exists
     try:
-        fa_invoice = list(fa_invoice)[0]
-    except IndexError:
-        fa_invoice = None
-    fa_invoice_data = {
-        "custom_id": invoice.id,
-        "subject_id": subject.id,
-        "order_number": invoice.order_number,
-        "lines": [],
-    }
-    if not fa_invoice:
-        fa_invoice_data["lines"] = create_invoice_lines(invoice=invoice)
-        fa_invoice = Invoice(**fa_invoice_data)
-        state = "Create"
-        subject_custom_id = ""
-    else:
-        fa_invoice.lines = []
-        fa.save(fa_invoice)
-        fa_invoice_data["lines"] = create_invoice_lines(invoice=invoice)
-        fa_invoice.update(fa_invoice_data)
-        state = "Update"
-        subject_custom_id = f"with custom_id = {fa_invoice.custom_id}"
-    try:
-        fa.save(fa_invoice)
-    except (
-        requests.RequestException,
-        requests.ConnectionError,
-        requests.HTTPError,
-        requests.URLRequired,
-        requests.TooManyRedirects,
-        requests.Timeout,
-    ) as error:
+        response = session.get(f"{base_url}/invoices.json", params={"custom_id": invoice.id})
+        response.raise_for_status()
+        invoices = response.json()
+
+        fa_invoice_data = {
+            "custom_id": str(invoice.id),
+            "subject_id": subject["id"],
+            "order_number": invoice.order_number,
+            "lines": create_invoice_lines(invoice=invoice)
+        }
+
+        if invoices:
+            # Update existing invoice
+            invoice_id = invoices[0]["id"]
+            state = "Update"
+            invoice_custom_id = f"with custom_id = {invoice.id}"
+
+            # First, clear existing lines
+            response = session.patch(
+                f"{base_url}/invoices/{invoice_id}.json",
+                json={"lines": []}
+            )
+            response.raise_for_status()
+
+            # Then update with new data
+            response = session.patch(
+                f"{base_url}/invoices/{invoice_id}.json",
+                json=fa_invoice_data
+            )
+            response.raise_for_status()
+            return response.json()
+        else:
+            # Create new invoice
+            state = "Create"
+            invoice_custom_id = ""
+            response = session.post(
+                f"{base_url}/invoices.json",
+                json=fa_invoice_data
+            )
+            response.raise_for_status()
+            return response.json()
+    except requests.RequestException as error:
         logger.error(
             error_message.format(
                 state=state,
-                subject_custom_id=subject_custom_id,
-                fakturoid_user_account_slug=fa.slug,
+                invoice_custom_id=invoice_custom_id,
+                fakturoid_account=base_url.split("/")[-2],
                 error=error,
             )
         )
-        fa_invoice = None
-    return fa_invoice
+        return None
 
 
-def get_fakturoid_api(account):
-    """Get Fakturoid API class instance
+def obtain_access_token(client_id, client_secret):
+    """Obtain or refresh OAuth access token for Fakturoid API V3
 
     :param str account: Fakturoid account type "production" or "test"
 
-    :return class instance fakturoid.Fakturoid/None fa: Fakturoid API class
-                                                        instance or None
+    :return str/None: Access token or None if failed
     """
     error_message = (
-        "Get Fakturoid API instance wasn't succesfull with Fakturoid"
-        " account '{fakturoid_user_account_slug}' due error: '{error}'"
+        "Obtaining access token wasn't successful with Fakturoid"
+        " client_id '{client_id}' due error: '{error}'"
     )
+
+    # Create the authorization header using HTTP Basic auth
+    auth_string = f"{client_id}:{client_secret}"
+    auth_bytes = auth_string.encode('ascii')
+    auth_b64 = base64.b64encode(auth_bytes).decode('ascii')
+
+    # Common headers for all requests
+    headers = {
+        'Accept': 'application/json',
+        'Authorization': f'Basic {auth_b64}'
+    }
+
+    data = {
+        'grant_type': "client_credentials",
+    }
+
+    # Try with JSON content type first
+    json_headers = headers.copy()
+    json_headers['Content-Type'] = 'application/json'
+
+    response = requests.post(
+        'https://app.fakturoid.cz/api/v3/oauth/token',
+        json=data,
+        headers=json_headers
+    )
+
     try:
-        fa = Fakturoid(
-            slug=settings.FAKTUROID[account]["user_account"],
-            email=settings.FAKTUROID[account]["user_email"],
-            api_key=settings.FAKTUROID[account]["api_key"],
-            user_agent=settings.FAKTUROID[account]["user_agent_header"],
-        )
-    except (
-        requests.RequestException,
-        requests.ConnectionError,
-        requests.HTTPError,
-        requests.URLRequired,
-        requests.TooManyRedirects,
-        requests.Timeout,
-    ) as error:
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
         logger.error(
             error_message.format(
-                fakturoid_user_account_slug=fa.slug,
+                client_id=client_id,
+                error=str(e)
+            )
+        )
+        return None
+
+    token_data = response.json()
+
+    return token_data['access_token']
+
+
+def create_api_session(account):
+    """Create authenticated session for Fakturoid API V3 using OAuth
+
+    :param str account: Fakturoid account type "production" or "test"
+
+    :return tuple: (session, base_url) or (None, None)
+    """
+    error_message = (
+        "Creating Fakturoid API session wasn't successful with Fakturoid"
+        " account '{fakturoid_account}' due error: '{error}'"
+    )
+
+    try:
+        # Get access token
+        access_token = obtain_access_token(
+            client_id=settings.FAKTUROID[account]["client_id"],
+            client_secret=settings.FAKTUROID[account]["client_secret"],
+        )
+        
+        if not access_token:
+            return None, None
+
+        # Create session with OAuth Bearer token
+        session = requests.Session()
+        session.headers.update({
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {access_token}"
+        })
+
+        slug = settings.FAKTUROID[account]["user_account"]
+        base_url = f"https://app.fakturoid.cz/api/v3/accounts/{slug}"
+
+        # Test the connection
+        response = session.get(f"{base_url}/account.json")
+        response.raise_for_status()
+
+        return session, base_url
+    except requests.RequestException as error:
+        logger.error(
+            error_message.format(
+                fakturoid_account=settings.FAKTUROID[account]["user_account"],
                 error=error,
             )
         )
-        fa = None
-    return fa
+        return None, None
+
+
+def send_invoice_by_email(session, base_url, invoice_data, fakturoid_account):
+    """Send invoice by email using API V3
+
+    :param session: requests session with authentication
+    :param str base_url: Base URL for API calls
+    :param dict invoice_data: Fakturoid invoice data
+    :param str fakturoid_account: Fakturoid account type
+    """
+    error_message = (
+        "Sending Fakturoid invoice with id={invoice_id}"
+        " by email wasn't successful with Fakturoid account"
+        " '{fakturoid_account}' due error: '{error}'"
+    )
+
+    try:
+        data = {}
+        if fakturoid_account == "test":
+            data = {"email": settings.FAKTUROID[fakturoid_account]["user_email"]}
+
+        response = session.post(
+            f"{base_url}/invoices/{invoice_data['id']}/message.json",
+            json=data
+        )
+        response.raise_for_status()
+    except requests.RequestException as error:
+        logger.error(
+            error_message.format(
+                invoice_id=invoice_data["id"],
+                fakturoid_account=base_url.split("/")[-2],
+                error=error,
+            )
+        )
 
 
 def generate_invoice(invoice, fakturoid_account=None):
-    """Generate Fakturoid invoice
+    """Generate Fakturoid invoice using API V3
 
-    :param class instance: Invoice model class instance
-    :param str account: Fakturoid account type "production" or "test"
+    :param class instance invoice: Invoice model class instance
+    :param str fakturoid_account: Fakturoid account type "production" or "test"
 
-    :return Fakturoid Invoice class instance/None fa_invoice: Fakturoid
-                                                              Invoice or
-                                                              None
+    :return dict/None: Fakturoid Invoice data or None
     """
     fa_invoice = None
     date_from_create_invoices = settings.FAKTUROID["date_from_create_invoices"]
+
     if not fakturoid_account:
         if not date_from_create_invoices or not invoice.generate_fakturoid_invoice:
             fakturoid_account = "test"
         else:
             fakturoid_account = "production"
+
     if settings.FAKTUROID[fakturoid_account]["user_account"]:
-        fa = get_fakturoid_api(account=fakturoid_account)
-        if fa:
+        session, base_url = create_api_session(account=fakturoid_account)
+
+        if session and base_url:
             # Subject
-            fa_subject = create_or_update_subject(fa=fa, invoice=invoice)
+            fa_subject = create_or_update_subject(
+                session=session, 
+                base_url=base_url, 
+                invoice=invoice
+            )
+
             if fa_subject:
                 # Invoice
                 fa_invoice = create_or_update_invoice(
-                    fa=fa,
+                    session=session,
+                    base_url=base_url,
                     invoice=invoice,
                     subject=fa_subject,
                 )
+
                 # Send email
-                send_invoice_by_email(
-                    invoice=fa_invoice,
-                    fa=fa,
-                    fakturoid_account=fakturoid_account,
-                )
-        return fa_invoice
+                if fa_invoice:
+                    send_invoice_by_email(
+                        session=session,
+                        base_url=base_url,
+                        invoice_data=fa_invoice,
+                        fakturoid_account=fakturoid_account,
+                    )
+
+    return fa_invoice

--- a/apps/dpnk/fakturoid_invoice_gen.py
+++ b/apps/dpnk/fakturoid_invoice_gen.py
@@ -352,7 +352,7 @@ def obtain_access_token(client_id, client_secret):
     json_headers['Content-Type'] = 'application/json'
 
     response = requests.post(
-        'https://app.fakturoid.cz/api/v3/oauth/token',
+        settings.FAKTUROID["base_rest_api_url"] + '/oauth/token',
         json=data,
         headers=json_headers
     )
@@ -403,7 +403,8 @@ def create_api_session(account):
         })
 
         slug = settings.FAKTUROID[account]["user_account"]
-        base_url = f"https://app.fakturoid.cz/api/v3/accounts/{slug}"
+        fa_base_url = settings.FAKTUROID["base_rest_api_url"]
+        base_url = f"{fa_base_url}/accounts/{slug}"
 
         # Test the connection
         response = session.get(f"{base_url}/account.json")

--- a/apps/dpnk/models/invoice.py
+++ b/apps/dpnk/models/invoice.py
@@ -399,7 +399,7 @@ def create_and_send_invoice_files(sender, instance, created, **kwargs):
     if created:
         fa_invoice = fakturoid_invoice_gen.generate_invoice(invoice=instance)
         if fa_invoice:
-            instance.fakturoid_invoice_url = fa_invoice.public_html_url
+            instance.fakturoid_invoice_url = fa_invoice["public_html_url"]
             instance.save(update_fields=["fakturoid_invoice_url"])
 
 

--- a/apps/dpnk/test/mommy_recipes.py
+++ b/apps/dpnk/test/mommy_recipes.py
@@ -19,7 +19,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 import datetime
 
-
 from dpnk.models import Campaign, CampaignType, UserAttendance
 
 from model_mommy.recipe import Recipe, related

--- a/apps/dpnk/test/test_fakturoid_invoice_gen.py
+++ b/apps/dpnk/test/test_fakturoid_invoice_gen.py
@@ -7,7 +7,13 @@ from model_mommy import mommy
 
 from .mommy_recipes import testing_campaign
 
-from ..fakturoid_invoice_gen import generate_invoice, create_api_session, delete_invoice, get_invoice, delete_subject
+from ..fakturoid_invoice_gen import (
+    generate_invoice,
+    create_api_session,
+    delete_invoice,
+    get_invoice,
+    delete_subject,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,34 +42,36 @@ class TestGenerateFakturoidInvoice(TestCase):
 
     def tearDown(self):
         if self.fa_invoice:
-          error_message = (
-              "Delete Fakturoid '{model}' with id = {model_id}"
-              " wasn't succesfull with Fakturoid account"
-              " '{fakturoid_user_account_slug}' due error: '{error}'"
-          )
-          try:
-              model = "Invoice"
-              model_id = self.fa_invoice["custom_id"]
-              delete_invoice(self.session, self.base_url, model_id)
-              model = "Subject"
-              model_id = self.fa_invoice["subject_id"]
-              delete_subject(self.session, self.base_url, self.fa_invoice["subject_id"])
-          except (
-              requests.RequestException,
-              requests.ConnectionError,
-              requests.HTTPError,
-              requests.URLRequired,
-              requests.TooManyRedirects,
-              requests.Timeout,
-          ) as error:
-              logger.error(
-                  error_message.format(
-                      model_id=model_id,
-                      model=model,
-                      fakturoid_user_account_slug=fa.slug,
-                      error=error,
-                  )
-              )
+            error_message = (
+                "Delete Fakturoid '{model}' with id = {model_id}"
+                " wasn't succesfull with Fakturoid account"
+                " '{fakturoid_user_account_slug}' due error: '{error}'"
+            )
+            try:
+                model = "Invoice"
+                model_id = self.fa_invoice["custom_id"]
+                delete_invoice(self.session, self.base_url, model_id)
+                model = "Subject"
+                model_id = self.fa_invoice["subject_id"]
+                delete_subject(
+                    self.session, self.base_url, self.fa_invoice["subject_id"]
+                )
+            except (
+                requests.RequestException,
+                requests.ConnectionError,
+                requests.HTTPError,
+                requests.URLRequired,
+                requests.TooManyRedirects,
+                requests.Timeout,
+            ) as error:
+                logger.error(
+                    error_message.format(
+                        model_id=model_id,
+                        model=model,
+                        fakturoid_user_account_slug=fa.slug,
+                        error=error,
+                    )
+                )
 
     def test_generate_fakturoid_invoice(self):
         fa_invoice = generate_invoice(

--- a/apps/dpnk/test/test_fakturoid_invoice_gen.py
+++ b/apps/dpnk/test/test_fakturoid_invoice_gen.py
@@ -7,48 +7,15 @@ from model_mommy import mommy
 
 from .mommy_recipes import testing_campaign
 
-from ..fakturoid_invoice_gen import get_fakturoid_api, generate_invoice
+from ..fakturoid_invoice_gen import generate_invoice, create_api_session, delete_invoice, get_invoice, delete_subject
 
 logger = logging.getLogger(__name__)
 
 
 class TestGenerateFakturoidInvoice(TestCase):
-    @staticmethod
-    def deleteFakturoidModels(fa, fa_invoice):
-        error_message = (
-            "Delete Fakturoid '{model}' with id = {model_id}"
-            " wasn't succesfull with Fakturoid account"
-            " '{fakturoid_user_account_slug}' due error: '{error}'"
-        )
-        try:
-            model = "Invoice"
-            model_id = fa_invoice.id
-            fa.delete(fa_invoice)
-            model = "Subject"
-            model_id = fa_invoice.subject_id
-            fa.delete(
-                fa.subject(fa_invoice.subject_id),
-            )
-        except (
-            requests.RequestException,
-            requests.ConnectionError,
-            requests.HTTPError,
-            requests.URLRequired,
-            requests.TooManyRedirects,
-            requests.Timeout,
-        ) as error:
-            logger.error(
-                error_message.format(
-                    model_id=model_id,
-                    model=model,
-                    fakturoid_user_account_slug=fa.slug,
-                    error=error,
-                )
-            )
-
     def setUp(self):
         self.fakturoid_account = "test"
-        self.fa = get_fakturoid_api(account=self.fakturoid_account)
+        self.session, self.base_url = create_api_session(self.fakturoid_account)
         self.company_name = "Test s.r.o."
         self.payment_amount = 1500
         self.invoice = mommy.make(
@@ -69,10 +36,34 @@ class TestGenerateFakturoidInvoice(TestCase):
 
     def tearDown(self):
         if self.fa_invoice:
-            TestGenerateFakturoidInvoice.deleteFakturoidModels(
-                fa=self.fa,
-                fa_invoice=self.fa_invoice,
-            )
+          error_message = (
+              "Delete Fakturoid '{model}' with id = {model_id}"
+              " wasn't succesfull with Fakturoid account"
+              " '{fakturoid_user_account_slug}' due error: '{error}'"
+          )
+          try:
+              model = "Invoice"
+              model_id = self.fa_invoice["custom_id"]
+              delete_invoice(self.session, self.base_url, model_id)
+              model = "Subject"
+              model_id = self.fa_invoice["subject_id"]
+              delete_subject(self.session, self.base_url, self.fa_invoice["subject_id"])
+          except (
+              requests.RequestException,
+              requests.ConnectionError,
+              requests.HTTPError,
+              requests.URLRequired,
+              requests.TooManyRedirects,
+              requests.Timeout,
+          ) as error:
+              logger.error(
+                  error_message.format(
+                      model_id=model_id,
+                      model=model,
+                      fakturoid_user_account_slug=fa.slug,
+                      error=error,
+                  )
+              )
 
     def test_generate_fakturoid_invoice(self):
         fa_invoice = generate_invoice(
@@ -80,15 +71,13 @@ class TestGenerateFakturoidInvoice(TestCase):
             fakturoid_account=self.fakturoid_account,
         )
         self.assertIsNotNone(fa_invoice)
-        self.fa_invoice = list(
-            self.fa.invoices(custom_id=self.invoice.id),
-        )[0]
+        self.fa_invoice = get_invoice(self.session, self.base_url, self.invoice.id)
         self.assertEqual(
-            self.fa_invoice.client_name,
+            self.fa_invoice["client_name"],
             self.company_name,
         )
-        self.assertEqual(len(self.fa_invoice.lines), 1)
+        self.assertEqual(len(self.fa_invoice["lines"]), 1)
         self.assertEqual(
-            self.fa_invoice.lines[0].unit_price,
+            float(self.fa_invoice["lines"][0]["unit_price"]),
             self.payment_amount,
         )

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -913,8 +913,11 @@ FAKTUROID = {
         "user_email": os.getenv(
             "FAKTUROID_PRODUCTION_USER_EMAIL",
         ),
-        "api_key": os.getenv(
-            "FAKTUROID_PRODUCTION_API_KEY",
+        "client_id": os.getenv(
+            "FAKTUROID_PRODUCTION_CLIENT_ID",
+        ),
+        "client_secret": os.getenv(
+            "FAKTUROID_PRODUCTION_CLIENT_SECRET",
         ),
         "user_agent_header": os.getenv(
             "FAKTUROID_PRODUCTION_USER_AGENT_HEADER",
@@ -927,8 +930,11 @@ FAKTUROID = {
         "user_email": os.getenv(
             "FAKTUROID_TEST_USER_EMAIL",
         ),
-        "api_key": os.getenv(
-            "FAKTUROID_TEST_API_KEY",
+        "client_id": os.getenv(
+            "FAKTUROID_TEST_CLIENT_ID",
+        ),
+        "client_secret": os.getenv(
+            "FAKTUROID_TEST_CLIENT_SECRET",
         ),
         "user_agent_header": os.getenv(
             "FAKTUROID_TEST_USER_AGENT_HEADER",

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -905,6 +905,7 @@ FAKTUROID = {
     ),
     "base_rest_api_url": os.getenv(
         "FAKTUROID_BASE_REST_API_URL",
+        "https://app.fakturoid.cz/api/v3",
     ),
     "production": {
         "user_account": os.getenv(


### PR DESCRIPTION
I'm having trouble testing this and I'm not sure what I'm doing wrong. I'm getting:

```
(do-prace-na-kole-py3.9) test@3bbf1d9ab2c6:/app-v$ ./single-pytest.sh apps/dpnk/test/test_fakturoid_invoice_gen.py
======================= test session starts ========================
platform linux -- Python 3.9.21, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /app-v/.venv/bin/python
cachedir: .pytest_cache
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
django: settings: project.settings.dev (from env)
rootdir: /app-v, configfile: pytest.ini
plugins: benchmark-3.4.1, django-webtest-1.9.10, celery-4.4.5, django-4.5.2, Faker-15.1.1, cov-3.0.0
collected 2 items

apps/dpnk/test/test_fakturoid_invoice_gen.py::TestGenerateFakturoidInvoice::test_generate_fakturoid_invoice PASSED [ 50%]
apps/dpnk/test/test_fakturoid_invoice_gen.py::testing_campaign <- apps/dpnk/test/mommy_recipes.py FAILED [100%]
>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>

    def get_campaign():
        try:
>           campaign = Campaign.objects.get(**kwargs)

apps/dpnk/test/mommy_recipes.py:77:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.venv/lib/python3.9/site-packages/django/db/models/manager.py:82: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.9/site-packages/django/db/models/query.py:402: in get
    num = len(clone)
.venv/lib/python3.9/site-packages/django/db/models/query.py:256: in __len__
    self._fetch_all()
.venv/lib/python3.9/site-packages/django/db/models/query.py:1242: in _fetch_all
    self._result_cache = list(self._iterable_class(self))
.venv/lib/python3.9/site-packages/django/db/models/query.py:55: in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
.venv/lib/python3.9/site-packages/django/db/models/sql/compiler.py:1140: in execute_sql
    cursor = self.connection.cursor()
.venv/lib/python3.9/site-packages/django/db/backends/base/base.py:256: in cursor
    return self._cursor()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.contrib.gis.db.backends.postgis.base.DatabaseWrapper object at 0x7fdd1b663670>
name = None

    def _cursor(self, name=None):
>       self.ensure_connection()
E       RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
```

Am I launching the test correctly?